### PR TITLE
docs: Add release notes and update README for v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,198 @@
+# Changelog
+
+All notable changes to the CookConnect project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2025-11-18
+
+### Added
+
+#### Microservices Architecture
+- **User Service** (v0.1.0) - Complete user management microservice
+  - User registration and profile management
+  - Password management (add/update passwords)
+  - Extended profiles with demographics and addresses
+  - Privacy controls for user data
+  - Full CRUD operations via REST API
+  - Health monitoring with Spring Boot Actuator
+
+- **Recipe Service** (v0.1.0) - Recipe management microservice
+  - Recipe creation (simple and detailed modes)
+  - Recipe retrieval (individual and list all)
+  - Ingredient management with quantities and measurements
+  - Step-by-step cooking instructions
+  - Recipe categorization with tags
+  - Visibility controls (private, public, friends-only)
+  - Full CRUD operations via REST API
+
+- **Social Service** (v0.1.0) - Social features microservice
+  - User follow/unfollow functionality
+  - Recipe bookmarking system
+  - Cookbook collections with full CRUD
+  - Cookbook entries and notes management
+  - Social profile management
+  - Full REST API implementation
+
+#### Infrastructure Services
+- **Config Server** (v0.1.0) - Centralized configuration management
+  - Spring Cloud Config Server implementation
+  - Git-backed configuration repository support
+  - Environment-specific configurations (dev, prod)
+  - Encryption support for sensitive configuration values
+  - Configuration serving for all microservices
+
+- **Eureka Server** (v0.1.0) - Service discovery
+  - Netflix Eureka service registry implementation
+  - Dynamic service registration and discovery
+  - Health monitoring and heartbeat tracking
+  - Diagnostic logging for service registration events
+  - Integration with all microservices
+
+- **Gateway Server** (v0.1.0) - API Gateway
+  - Spring Cloud Gateway implementation
+  - Reactive WebFlux-based routing
+  - Eureka integration for dynamic service routing
+  - Centralized entry point for all microservices
+  - Actuator endpoints for gateway health monitoring
+
+#### Development Infrastructure
+- **Maven Multi-Module Project Structure**
+  - Parent POM with unified dependency management
+  - Automatic version management for parent POM
+  - Standardized build configuration across all modules
+  - Spring Boot 3.5.6 and Spring Cloud 2025.0.0 integration
+
+- **Docker Support**
+  - Jib Maven Plugin integration for containerization
+  - Automated Docker image building during package phase
+  - MySQL database stack with Docker Compose
+  - Separate databases for each microservice (database-per-service pattern)
+  - Docker network configuration for service communication
+
+- **Testing Framework**
+  - Gatling performance testing module
+  - Load testing capabilities for all services
+  - Configurable test scenarios
+  - Performance metrics and reporting
+
+#### Data Layer
+- **Database Architecture**
+  - MySQL 9.4 for all services
+  - Database-per-service pattern implementation
+  - Spring Data JPA / Hibernate ORM
+  - JPA entities with proper relationships
+  - Automatic schema generation and migration support
+
+- **Data Transfer Layer**
+  - MapStruct-based object mapping
+  - DTO pattern implementation across all services
+  - Type-safe entity-to-DTO conversions
+  - Lombok integration for reduced boilerplate
+
+#### API Features
+- **RESTful API Endpoints**
+  - User Service API at port 8081 (`/cc-user`)
+  - Recipe Service API at port 8082 (`/recipes`)
+  - Social Service API at port 8083 (`/social`, `/cookbook`)
+  - Config Server at port 8888
+  - Eureka Server at port 8761
+  - Consistent REST patterns across all services
+
+- **Error Handling**
+  - Global exception handling for all services
+  - Consistent error response format
+  - Proper HTTP status codes
+  - Detailed error messages for debugging
+
+#### Configuration Management
+- **Externalized Configuration**
+  - Separate Git repository for all configurations
+  - Environment-specific property files
+  - Global shared configurations
+  - Service-specific configurations
+  - Support for configuration encryption
+
+#### Build & CI/CD
+- **GitHub Actions Workflows**
+  - Automated version validation on pull requests
+  - Semantic versioning enforcement
+  - Auto-increment parent POM version
+  - Service version change detection
+  - Validation reporting in PR comments
+
+- **Version Management**
+  - Strict semantic versioning (SemVer) enforcement
+  - Automated parent POM versioning
+  - Manual service versioning with validation
+  - Version increment validation (+1 only)
+  - Reset rules for minor/major version bumps
+
+#### Documentation
+- **Project Documentation**
+  - Comprehensive README with setup instructions
+  - API endpoint documentation with examples
+  - Architecture diagrams and explanations
+  - Configuration management guide
+  - Troubleshooting guide
+  - Development workflow documentation
+
+- **Technical Documentation**
+  - Product Definition Document (PDD)
+  - Data domain documentation
+  - Architecture deviations analysis
+  - Maven setup guide
+  - Prerequisites and running services guides
+
+### Changed
+- Migrated all services from `application.properties` to `application.yml` for better readability
+- Renamed `database-compose.yml` to `docker-compose.yml` in docker/databases directory
+- Updated all services to use `@EnableDiscoveryClient` annotation
+- Enhanced service startup with Eureka registration
+- Configured services to fetch configuration from Config Server
+
+### Technical Details
+
+#### Technology Stack
+- **Language**: Java 21 (LTS)
+- **Framework**: Spring Boot 3.5.6
+- **Cloud**: Spring Cloud 2025.0.0
+- **Database**: MySQL 9.4
+- **Build Tool**: Maven 3.x
+- **Containerization**: Docker, Jib
+- **Service Discovery**: Netflix Eureka
+- **API Gateway**: Spring Cloud Gateway
+- **Config Management**: Spring Cloud Config
+- **Object Mapping**: MapStruct 1.5.5
+- **Utilities**: Lombok 1.18.42
+- **Monitoring**: Spring Boot Actuator
+- **Testing**: Gatling 3.13.5
+
+#### Service Ports
+- Config Server: 8888
+- Eureka Server: 8761
+- Gateway Server: 8080
+- User Service: 8081
+- Recipe Service: 8082
+- Social Service: 8083
+- Users Database: 3308
+- Recipes Database: 3306
+- Socials Database: 3307
+
+### Infrastructure
+- Docker Compose for database orchestration
+- Separate MySQL instances for each microservice
+- Centralized configuration repository (CookConnect-config)
+- Service discovery with Eureka
+- API Gateway for unified access
+
+### Notes
+- This is the first official release of CookConnect
+- All core microservices are functional with CRUD operations
+- Service discovery and API gateway are operational
+- Configuration management is fully externalized
+- Database-per-service pattern is implemented
+- Ready for further feature development and integration testing
+
+[0.1.0]: https://github.com/tkm3d1a/CookConnect/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > A practical recipe management platform with social features, built with Spring Boot microservices
 
-[![Version](https://img.shields.io/badge/version-0.0.5-blue.svg)](https://github.com/tkm3d1a/cookconnect)
+[![Version](https://img.shields.io/badge/version-0.1.0-blue.svg)](https://github.com/tkm3d1a/cookconnect)
 [![Java](https://img.shields.io/badge/Java-21-orange.svg)](https://openjdk.java.net/)
 [![Spring Boot](https://img.shields.io/badge/Spring%20Boot-3.5.6-brightgreen.svg)](https://spring.io/projects/spring-boot)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
@@ -51,7 +51,7 @@ To simplify recipe management for home cooks while fostering a supportive commun
 
 ## Current Status
 
-**Version**: 0.0.5 - CRUD Phase Complete
+**Version**: 0.1.0 - Service Discovery & Gateway Complete
 
 ### ✅ Completed
 - [x] Microservices architecture foundation
@@ -66,20 +66,22 @@ To simplify recipe management for home cooks while fostering a supportive commun
 - [x] Global exception handling for all services
 - [x] DTO pattern with MapStruct mappers
 - [x] Service layer business logic
+- [x] Service discovery (Eureka Server)
+- [x] API Gateway (Spring Cloud Gateway)
+- [x] Performance testing framework (Gatling)
 
 ### 🚧 In Progress
 - [ ] API documentation (Swagger/OpenAPI - Issue #6)
-- [ ] Service-to-service communication
+- [ ] Service-to-service communication through Gateway
 - [ ] Authentication and authorization (planned: Keycloak)
 - [ ] Comprehensive test coverage
 
 ### 📋 Planned
 - [ ] Frontend application
-- [ ] API Gateway
-- [ ] Service discovery (Eureka)
 - [ ] Circuit breakers and resilience patterns
 - [ ] Pagination for list endpoints
 - [ ] Advanced search and filtering
+- [ ] Load balancing and routing rules
 
 ## Features
 
@@ -173,24 +175,37 @@ CookConnect follows a **microservices architecture** with database-per-service p
 ### Services
 
 ```
-┌──────────────────────────────────────────────────────────────┐
-│                     CookConnect Platform                     │
-├─────────────────┬─────────────────┬──────────────────────────┤
-│  User Service   │ Recipe Service  │   Social Service         │
-│                 │                 │                          │
-│ • User Identity │ • Recipe Data   │ • Social Graph           │
-│ • Profiles      │ • Ingredients   │ • Bookmarks              │
-│ • Addresses     │ • Instructions  │ • Cookbooks              │
-│ • Auth          │ • Tags          │ • Follows                │
-│                 │                 │                          │
-│  users-db       │  recipes-db     │  socials-db              │
-│  (MySQL)        │  (MySQL)        │  (MySQL)                 │
-└─────────────────┴─────────────────┴──────────────────────────┘
-                           │
-                  ┌────────┴────────┐
-                  │  Config Server  │
-                  │ (Spring Cloud)  │
-                  └─────────────────┘
+                    ┌─────────────────────┐
+                    │   API Gateway       │
+                    │   (Port 8080)       │
+                    │  Spring Cloud GW    │
+                    └──────────┬──────────┘
+                               │
+              ┌────────────────┼────────────────┐
+              │                │                │
+    ┌─────────▼────────┐  ┌───▼──────────┐  ┌──▼──────────────┐
+    │  User Service    │  │Recipe Service│  │ Social Service  │
+    │   (Port 8081)    │  │ (Port 8082)  │  │  (Port 8083)    │
+    │                  │  │              │  │                 │
+    │ • User Identity  │  │ • Recipes    │  │ • Social Graph  │
+    │ • Profiles       │  │ • Ingredients│  │ • Bookmarks     │
+    │ • Addresses      │  │ • Instructions│ │ • Cookbooks     │
+    │ • Auth           │  │ • Tags       │  │ • Follows       │
+    │                  │  │              │  │                 │
+    │  users-db        │  │  recipes-db  │  │  socials-db     │
+    │  (MySQL:3308)    │  │(MySQL:3306)  │  │ (MySQL:3307)    │
+    └──────────────────┘  └──────────────┘  └─────────────────┘
+              │                │                │
+              └────────────────┼────────────────┘
+                               │
+              ┌────────────────┼────────────────┐
+              │                │                │
+    ┌─────────▼────────┐  ┌───▼──────────┐     │
+    │  Eureka Server   │  │Config Server │     │
+    │   (Port 8761)    │  │ (Port 8888)  │     │
+    │ Service Discovery│◄─┤Centralized   │◄────┘
+    │                  │  │Configuration │
+    └──────────────────┘  └──────────────┘
 ```
 
 ### Design Principles
@@ -208,9 +223,11 @@ CookConnect provides RESTful APIs for all microservices. Each service runs on a 
 
 | Service | Port | Base URL | Status |
 |---------|------|----------|--------|
+| API Gateway | 8080 | `http://localhost:8080` | ✅ Active |
 | User Service | 8081 | `http://localhost:8081` | ✅ Active |
 | Recipe Service | 8082 | `http://localhost:8082` | ✅ Active |
 | Social Service | 8083 | `http://localhost:8083` | ✅ Active |
+| Eureka Server | 8761 | `http://localhost:8761` | ✅ Active |
 | Config Server | 8888 | `http://localhost:8888` | ✅ Active |
 
 ### User Service API (`/cc-user`)
@@ -615,18 +632,48 @@ This compiles all microservices and runs tests.
 
 #### 7. Run Services
 
-**Important**: Services must be started in the correct order. The Config Server must start first, followed by other services.
+**Important**: Services must be started in the correct order for proper initialization.
+
+**Startup Order:**
+1. Config Server (8888)
+2. Eureka Server (8761)
+3. Gateway Server (8080)
+4. Microservices (8081-8083)
 
 **Step 1 - Start Config Server:**
 ```bash
-cd services/config-server
+cd servers/config-server
 mvn spring-boot:run
 ```
 
 Wait for the Config Server to fully start (look for "Started ConfigServerApplication" in the logs).
 The Config Server will be available at `http://localhost:8888`.
 
-**Step 2 - Start Microservices** (in separate terminal windows):
+**Step 2 - Start Eureka Server:**
+
+Open a new terminal window and set environment variables.
+
+```bash
+cd servers/eureka-server
+mvn spring-boot:run
+```
+
+Wait for Eureka to start (look for "Started EurekaserverApplication" in the logs).
+Access the Eureka dashboard at `http://localhost:8761`.
+
+**Step 3 - Start Gateway Server:**
+
+Open a new terminal window and set environment variables.
+
+```bash
+cd servers/gateway-server
+mvn spring-boot:run
+```
+
+Wait for the Gateway to start and register with Eureka.
+The Gateway will be available at `http://localhost:8080`.
+
+**Step 4 - Start Microservices** (in separate terminal windows):
 
 Open new terminal windows for each service and set environment variables in each.
 
@@ -648,7 +695,10 @@ cd services/social-service
 mvn spring-boot:run
 ```
 
-Each service will connect to the Config Server on startup to fetch its configuration.
+Each service will:
+- Connect to the Config Server to fetch its configuration
+- Register with Eureka Server for service discovery
+- Become available through the API Gateway
 
 #### 8. Verify Installation
 
@@ -660,13 +710,31 @@ docker ps
 
 You should see three MySQL containers running.
 
-Check service health:
+Check infrastructure services:
+```bash
+# Config Server
+curl http://localhost:8888/actuator/health
+
+# Eureka Server - view dashboard
+open http://localhost:8761  # macOS
+# or navigate to http://localhost:8761 in your browser
+
+# Gateway Server
+curl http://localhost:8080/actuator/health
+```
+
+Check microservices health:
 ```bash
 # Health check endpoints (Actuator)
 curl http://localhost:8081/actuator/health  # User Service
 curl http://localhost:8082/actuator/health  # Recipe Service
 curl http://localhost:8083/actuator/health  # Social Service
 ```
+
+Verify service registration with Eureka:
+- Open the Eureka dashboard at `http://localhost:8761`
+- You should see all services (Gateway, User, Recipe, Social) listed as registered instances
+- Each service should show status "UP"
 
 #### 9. Test the APIs
 
@@ -858,8 +926,8 @@ CookConnect/                               # Main application repository
 │   └── running-services.md                # Service running guide
 ├── docker/                                # Docker configurations
 │   ├── databases/                         # Database Docker Compose
-│   │   ├── database-compose.yml
-│   │   └── .env files
+│   │   ├── docker-compose.yml             # Database stack configuration
+│   │   └── .env files                     # Database environment variables
 │   └── [env-specific directories]         # IDE, test, stage, prod environments
 ├── services/                              # Microservices
 │   ├── user-service/                      # User management microservice
@@ -885,22 +953,40 @@ CookConnect/                               # Main application repository
 │   │   │   ├── errorhandler/              # Global exception handling
 │   │   │   └── config/                    # Service configuration
 │   │   └── pom.xml
-│   ├── social-service/                    # Social features microservice
-│   │   ├── src/main/java/com/tkforgeworks/cookconnect/socialservice/
-│   │   │   ├── controller/                # REST controllers (CookbookController, SocialInteractionController)
-│   │   │   ├── model/                     # Social entities
-│   │   │   │   ├── dto/                   # Data Transfer Objects
-│   │   │   │   └── mapper/                # MapStruct mappers
-│   │   │   ├── repository/                # Spring Data repositories
-│   │   │   ├── service/                   # Business logic
-│   │   │   ├── errorhandler/              # Global exception handling
-│   │   │   └── config/                    # Service configuration
-│   │   └── pom.xml
-│   └── config-server/                     # Spring Cloud Config Server
-│       ├── src/main/resources/
-│       │   └── application.properties     # Points to config repo
+│   └── social-service/                    # Social features microservice
+│       ├── src/main/java/com/tkforgeworks/cookconnect/socialservice/
+│       │   ├── controller/                # REST controllers (CookbookController, SocialInteractionController)
+│       │   ├── model/                     # Social entities
+│       │   │   ├── dto/                   # Data Transfer Objects
+│       │   │   └── mapper/                # MapStruct mappers
+│       │   ├── repository/                # Spring Data repositories
+│       │   ├── service/                   # Business logic
+│       │   ├── errorhandler/              # Global exception handling
+│       │   └── config/                    # Service configuration
 │       └── pom.xml
+├── servers/                               # Infrastructure servers
+│   ├── config-server/                     # Spring Cloud Config Server
+│   │   ├── src/main/resources/
+│   │   │   └── application.yml            # Config server settings
+│   │   └── pom.xml
+│   ├── eureka-server/                     # Netflix Eureka Service Discovery
+│   │   ├── src/main/java/com/tkforgeworks/cookconnect/eurekaserver/
+│   │   │   ├── EurekaserverApplication.java
+│   │   │   └── logging/                   # Eureka diagnostics
+│   │   ├── src/main/resources/
+│   │   │   └── application.yml            # Eureka server settings
+│   │   └── pom.xml
+│   └── gateway-server/                    # Spring Cloud Gateway
+│       ├── src/main/resources/
+│       │   └── application.yml            # Gateway routing configuration
+│       └── pom.xml
+├── testing/                               # Testing modules
+│   ├── gatling-tests/                     # Performance testing
+│   │   ├── src/test/java/                 # Gatling simulation scenarios
+│   │   └── pom.xml
+│   └── helper/                            # Testing utilities
 ├── pom.xml                                # Parent POM
+├── CHANGELOG.md                           # Release notes and version history
 └── README.md                              # This file
 
 CookConnect-config/                        # External configuration repository
@@ -912,9 +998,15 @@ CookConnect-config/                        # External configuration repository
 ├── social-service/
 │   ├── social-service.properties
 │   └── social-service-{profile}.properties
-└── user-service/
-    ├── user-service.properties
-    └── user-service-{profile}.properties
+├── user-service/
+│   ├── user-service.properties
+│   └── user-service-{profile}.properties
+├── eureka-server/
+│   ├── eureka-server.properties
+│   └── eureka-server-{profile}.properties
+└── gateway-server/
+    ├── gateway-server.properties
+    └── gateway-server-{profile}.properties
 ```
 
 **Note**: The `CookConnect-config` repository is separate and contains all service configurations. It must be cloned independently (see [Getting Started](#getting-started)).
@@ -966,6 +1058,31 @@ Handles social interactions including user follows, recipe bookmarks, and cookbo
 
 Centralized configuration management for all microservices using Spring Cloud Config.
 
+#### Eureka Server
+**Package**: `com.tkforgeworks.cookconnect.eurekaserver`
+**Port**: 8761
+
+Service discovery and registration using Netflix Eureka, enabling microservices to locate and communicate with each other dynamically.
+
+**Key Components**:
+- **Application**: `EurekaserverApplication` - Main Eureka Server application
+- **Diagnostics**: `EurekaDiagnostics` - Monitors and logs service registration events
+- **Features**: Service registration, health monitoring, instance management
+
+**Dashboard**: Access the Eureka dashboard at `http://localhost:8761` to view registered services and their status.
+
+#### Gateway Server
+**Package**: `com.tkforgeworks.cookconnect.gatewayserver`
+**Port**: 8080
+
+API Gateway providing a unified entry point for all microservices using Spring Cloud Gateway with reactive WebFlux.
+
+**Key Features**:
+- Dynamic routing to registered services via Eureka
+- Load balancing across service instances
+- Centralized cross-cutting concerns (future: authentication, rate limiting)
+- Reactive, non-blocking architecture
+
 ## Documentation
 
 Comprehensive documentation is available in the `/docs` directory:
@@ -1005,11 +1122,17 @@ Docker images are built using Jib Maven Plugin:
 cd services/user-service
 mvn compile jib:dockerBuild
 
+# Build image for a specific server
+cd servers/eureka-server
+mvn compile jib:dockerBuild
+
 # Images are tagged as:
 # tkforgeworks/cookconnect-user-service:latest
 # tkforgeworks/cookconnect-recipe-service:latest
 # tkforgeworks/cookconnect-social-service:latest
 # tkforgeworks/cookconnect-config-server:latest
+# tkforgeworks/cookconnect-eureka-server:latest
+# tkforgeworks/cookconnect-gateway-server:latest
 ```
 
 ### Running Tests
@@ -1369,7 +1492,7 @@ To skip validation for a specific PR (emergency fixes only):
 
 ## Roadmap
 
-### Version 0.1.0 (Current - CRUD Phase Complete) ✅
+### Version 0.1.0 (Released - Service Discovery & Gateway) ✅
 - ✅ Microservices architecture foundation
 - ✅ Data models and database schema
 - ✅ REST API implementation (CRUD operations)
@@ -1378,6 +1501,11 @@ To skip validation for a specific PR (emergency fixes only):
 - ✅ User service (full CRUD)
 - ✅ Recipe service (create/read operations)
 - ✅ Social service (full CRUD for cookbooks and interactions)
+- ✅ Config Server for centralized configuration
+- ✅ Eureka Server for service discovery
+- ✅ API Gateway with Spring Cloud Gateway
+- ✅ Performance testing framework with Gatling
+- ✅ Docker support with Jib
 
 ### Version 0.2.0 (Next - Enhanced Features)
 - Complete recipe service (update/delete operations)
@@ -1385,6 +1513,7 @@ To skip validation for a specific PR (emergency fixes only):
 - Swagger/OpenAPI documentation
 - Pagination for list endpoints
 - Enhanced error responses with validation
+- Gateway routing configurations for all services
 
 ### Version 0.3.0 (Authentication & Security)
 - Authentication with Keycloak
@@ -1392,14 +1521,15 @@ To skip validation for a specific PR (emergency fixes only):
 - Role-based access control (RBAC)
 - Secure inter-service communication
 - User registration and login flows
+- OAuth2 integration
 
 ### Version 1.0.0 (MVP - Production Ready)
-- API Gateway (Spring Cloud Gateway)
-- Service discovery (Eureka)
 - Circuit breakers and resilience patterns
 - Comprehensive test coverage (unit, integration, e2e)
 - Monitoring and observability (Prometheus, Grafana)
 - Complete recipe management features
+- Distributed tracing
+- Centralized logging
 
 ### Version 1.1
 - Media upload and recipe photos


### PR DESCRIPTION
- Add comprehensive CHANGELOG.md documenting all features in v0.1.0
- Update README version badge from 0.0.5 to 0.1.0
- Update Current Status section to reflect completed features
- Add Eureka Server and Gateway Server to architecture diagram
- Update service base URLs table with new infrastructure services
- Expand project structure to include servers and testing modules
- Add detailed documentation for Eureka and Gateway servers
- Update service startup instructions with correct order
- Add verification steps for Eureka service registration
- Update roadmap to show v0.1.0 as released
- Update Docker image build instructions for new servers

This documentation update provides comprehensive coverage of:
- Service discovery with Netflix Eureka
- API Gateway with Spring Cloud Gateway
- Performance testing framework with Gatling
- Complete architecture with all infrastructure components
- Step-by-step setup and verification procedures